### PR TITLE
Fixed the != operator for vectors.

### DIFF
--- a/include/Mathter/Vector/VectorCompare.hpp
+++ b/include/Mathter/Vector/VectorCompare.hpp
@@ -24,7 +24,7 @@ bool operator==(const Vector<T, Dim, Packed>& lhs, const Vector<T, Dim, Packed>&
 /// <remarks> &lt;The usual warning about floating point numbers&gt; </remarks>
 template <class T, int Dim, bool Packed>
 bool operator!=(const Vector<T, Dim, Packed>& lhs, const Vector<T, Dim, Packed>& rhs) {
-	return !operator==(rhs);
+	return !operator==(lhs, rhs);
 }
 
 } // namespace mathter


### PR DESCRIPTION
The vector != operator was implemented in terms of the == operator, but only the rhs was being passed in. So the function couldn't be resolved.